### PR TITLE
fix: Update GHCR login step to use HELM_PACKAGES_PAT for authentication

### DIFF
--- a/.github/workflows/publish-helm-charts.yaml
+++ b/.github/workflows/publish-helm-charts.yaml
@@ -26,7 +26,7 @@ jobs:
           version: v3.14.0
 
       - name: Log in to GHCR
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
+        run: echo "${{ secrets.HELM_PACKAGES_PAT }}" | helm registry login ghcr.io -u ${{ github.repository_owner }} --password-stdin
 
       - name: Package and Push Charts
         run: |

--- a/.github/workflows/update-wrapper-version.yaml
+++ b/.github/workflows/update-wrapper-version.yaml
@@ -2,9 +2,8 @@ name: Update wrapper chart version
 
 on:
   pull_request:
-    paths:
-      - 'charts/**/Chart.yaml'
-      - 'charts/**/Chart.lock'
+    branches:
+      - master
 
 permissions:
   contents: write


### PR DESCRIPTION
This pull request updates the authentication method for publishing Helm charts by switching from the default GitHub token to a dedicated Helm packages personal access token (PAT). This change helps improve security and ensures proper permissions when logging in to the GitHub Container Registry (GHCR).

Authentication update:

* Changed the login step in `.github/workflows/publish-helm-charts.yaml` to use `${{ secrets.HELM_PACKAGES_PAT }}` and `${{ github.repository_owner }}` instead of `${{ secrets.GITHUB_TOKEN }}` and `${{ github.actor }}` for GHCR authentication.