### PR TITLE
renovatebot: Add reviewers to renovate.json configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "reviewers": [
+    "team:core"
   ]
 }


### PR DESCRIPTION
This pull request makes a small configuration change to the `renovate.json` file, specifying that the `team:core` group should be assigned as reviewers for Renovate updates.